### PR TITLE
Add SpanKind and improve SpanName

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ helm-chart/charts/
 node_modules/
 api/.build/
 .vscode/
+.idea/

--- a/api/protos/pokeshop.proto
+++ b/api/protos/pokeshop.proto
@@ -6,9 +6,7 @@ option objc_class_prefix = "PKS";
 
 package pokeshop;
 
-// The greeting service definition.
 service Pokeshop {
-  // Sends a greeting
   rpc getPokemonList (GetPokemonRequest) returns (GetPokemonListResponse) {}
   rpc createPokemon (Pokemon) returns (Pokemon) {}
   rpc importPokemon (ImportPokemonRequest) returns (ImportPokemonRequest) {}
@@ -28,7 +26,6 @@ message GetPokemonListResponse {
   int32 totalCount = 2;
 }
 
-// The request message containing the user's name.
 message Pokemon {
   optional int32 id = 1;
   string name = 2;

--- a/api/src/middlewares/validation.ts
+++ b/api/src/middlewares/validation.ts
@@ -1,4 +1,4 @@
-import { SpanStatusCode } from '@opentelemetry/api';
+import { SpanKind, SpanStatusCode } from '@opentelemetry/api';
 import { createSpan, getParentSpan, runWithSpan } from '@pokemon/telemetry/tracing';
 import { transformAndValidate } from 'class-transformer-validator';
 import { CustomTags } from '../constants/Tags';
@@ -6,7 +6,7 @@ import { CustomTags } from '../constants/Tags';
 const validate = type => {
   return async function validate(ctx, next) {
     const parentSpan = await getParentSpan();
-    const span = await createSpan('validate request', parentSpan);
+    const span = await createSpan('validate request', parentSpan, { kind: SpanKind.INTERNAL });
 
     const body = ctx.request.body;
     try {

--- a/api/src/repositories/instrumented.repository.ts
+++ b/api/src/repositories/instrumented.repository.ts
@@ -1,4 +1,4 @@
-import { Span } from '@opentelemetry/api';
+import { Span, SpanKind } from '@opentelemetry/api';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { Pokemon, PokemonRepository, SearchOptions } from '@pokemon/repositories/pokemon.repository';
 import { InstrumentedComponent } from '@pokemon/telemetry/instrumented.component';
@@ -61,7 +61,7 @@ export class InstrumentedPokemonRepository extends InstrumentedComponent impleme
   }
 
   async create(pokemon: Pokemon): Promise<Pokemon> {
-    return this.instrumentMethod('save pokemon on database', async (span: Span) => {
+    return this.instrumentMethod('create pokeshop.pokemon', SpanKind.CLIENT, async (span: Span) => {
       const result = await this.repository.create(pokemon);
       const baseAttributes = this.getBaseAttributes();
 
@@ -76,7 +76,7 @@ export class InstrumentedPokemonRepository extends InstrumentedComponent impleme
   }
 
   async update(id: number, pokemon: Pokemon): Promise<Pokemon> {
-    return this.instrumentMethod('update pokemon on database', async (span: Span) => {
+    return this.instrumentMethod('update pokeshop.pokemon', SpanKind.CLIENT, async (span: Span) => {
       const result = await this.repository.update(id, pokemon);
 
       const baseAttributes = this.getBaseAttributes();
@@ -92,7 +92,7 @@ export class InstrumentedPokemonRepository extends InstrumentedComponent impleme
   }
 
   async delete(pokemonId: number): Promise<number> {
-    return this.instrumentMethod('delete pokemon from database', async (span: Span) => {
+    return this.instrumentMethod('delete pokeshop.pokemon', SpanKind.CLIENT, async (span: Span) => {
       const affectedRows = await this.repository.delete(pokemonId);
 
       const baseAttributes = this.getBaseAttributes();
@@ -108,7 +108,7 @@ export class InstrumentedPokemonRepository extends InstrumentedComponent impleme
   }
 
   findOne(id: number): Promise<Pokemon | null> {
-    return this.instrumentMethod('find a pokemon from database', async (span: Span) => {
+    return this.instrumentMethod('findOne pokeshop.pokemon', SpanKind.CLIENT, async (span: Span) => {
       const result = await this.repository.findOne(id);
 
       const baseAttributes = this.getBaseAttributes();
@@ -124,7 +124,7 @@ export class InstrumentedPokemonRepository extends InstrumentedComponent impleme
   }
 
   async findMany(options?: SearchOptions): Promise<Pokemon[]> {
-    return this.instrumentMethod('search pokemons from database', async (span: Span) => {
+    return this.instrumentMethod('findMany pokeshop.pokemon', SpanKind.CLIENT, async (span: Span) => {
       const result = await this.repository.findMany(options);
 
       const baseAttributes = this.getBaseAttributes();
@@ -140,7 +140,7 @@ export class InstrumentedPokemonRepository extends InstrumentedComponent impleme
   }
 
   async count(options?: SearchOptions): Promise<number> {
-    return this.instrumentMethod('count pokemons from database', async (span: Span) => {
+    return this.instrumentMethod('count pokeshop.pokemon', SpanKind.CLIENT, async (span: Span) => {
       const baseAttributes = await this.getBaseAttributes();
 
       const result = await this.repository.count(options);

--- a/api/src/services/cache.service.ts
+++ b/api/src/services/cache.service.ts
@@ -1,3 +1,4 @@
+import { SpanKind } from '@opentelemetry/api';
 import { Span } from '@opentelemetry/sdk-trace-base';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { InstrumentedComponent } from '@pokemon/telemetry/instrumented.component';
@@ -39,12 +40,12 @@ class InstrumentedCacheService<T> extends InstrumentedComponent implements Cache
   }
 
   async isAvailable(): Promise<boolean> {
-    return this.instrumentMethod('cache is available', async (span: Span) => {
+    return this.instrumentMethod('healthCheck', SpanKind.CLIENT, async (span: Span) => {
       const result = await this.cacheService.isAvailable();
 
       span.setAttributes({
         ...this.getBaseAttributes(),
-        [SemanticAttributes.DB_OPERATION]: 'healthcheck',
+        [SemanticAttributes.DB_OPERATION]: 'healthCheck',
         [CustomTags.DB_RESULT]: result,
       });
 
@@ -53,7 +54,7 @@ class InstrumentedCacheService<T> extends InstrumentedComponent implements Cache
   }
 
   async get(key: string): Promise<T | null> {
-    return this.instrumentMethod('get value from cache', async (span: Span) => {
+    return this.instrumentMethod(`get ${key}`, SpanKind.CLIENT, async (span: Span) => {
       const result = await this.cacheService.get(key);
 
       span.setAttributes({
@@ -68,8 +69,9 @@ class InstrumentedCacheService<T> extends InstrumentedComponent implements Cache
   }
 
   async set(key: string, value: T): Promise<void> {
-    return this.instrumentMethod('set value on cache', async (span: Span) => {
+    return this.instrumentMethod(`set ${key}`, SpanKind.CLIENT, async (span: Span) => {
       const result = this.cacheService.set(key, value);
+
       span.setAttributes({
         ...this.getBaseAttributes(),
         [SemanticAttributes.DB_OPERATION]: 'set',

--- a/api/src/services/pokeApi.service.ts
+++ b/api/src/services/pokeApi.service.ts
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch';
 import { snakeCase } from 'lodash';
 import { getParentSpan, createSpan, runWithSpan } from '@pokemon/telemetry/tracing';
-import { Span } from '@opentelemetry/api';
+import { Span, SpanKind } from '@opentelemetry/api';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { CustomTags } from '../constants/Tags';
 
@@ -25,7 +25,7 @@ class PokeAPIService {
 
   async getPokemon(id: string) {
     const parentSpan = await getParentSpan();
-    const span = await createSpan('get pokemon from pokeapi', parentSpan);
+    const span = await createSpan('HTTP GET pokeapi.pokemon', parentSpan, { kind: SpanKind.CLIENT });
 
     try {
       return await this.getPokemonFromAPi(id, span);

--- a/api/src/services/pokemonSyncronizer.service.ts
+++ b/api/src/services/pokemonSyncronizer.service.ts
@@ -1,8 +1,9 @@
+import { SpanKind } from '@opentelemetry/api';
 import { getPokemonRepository, Pokemon } from '@pokemon/repositories';
 import { createQueueService } from '@pokemon/services/queue.service';
 import { createSpan, getParentSpan, runWithSpan } from '@pokemon/telemetry/tracing';
 
-export const MESSAGE_GROUP = '/queue/syncronizePokemon';
+export const MESSAGE_GROUP = 'queue.synchronizePokemon';
 
 export type TPokemonSyncMessage = {
   id: number;
@@ -18,7 +19,7 @@ const PokemonSyncronizer = pokeApiService => {
     },
     async sync(pokemonId: Number) {
       const parentSpan = await getParentSpan();
-      const span = await createSpan('import pokemon', parentSpan);
+      const span = await createSpan('import pokemon', parentSpan, { kind: SpanKind.INTERNAL });
 
       try {
         return await runWithSpan(span, async () => {

--- a/api/src/telemetry/instrumented.component.ts
+++ b/api/src/telemetry/instrumented.component.ts
@@ -1,10 +1,14 @@
-import { SpanStatusCode, Span } from '@opentelemetry/api';
+import { Span, SpanKind, SpanStatusCode } from '@opentelemetry/api';
 import { createSpan, getParentSpan, runWithSpan } from '@pokemon/telemetry/tracing';
 
 export abstract class InstrumentedComponent {
-  protected async instrumentMethod<T>(spanName: string, innerMethod: (span?: Span) => Promise<T>): Promise<T> {
+  protected async instrumentMethod<T>(
+    spanName: string,
+    spanKind: SpanKind | undefined,
+    innerMethod: (span?: Span) => Promise<T>
+  ): Promise<T> {
     const parentSpan = await getParentSpan();
-    const span = await createSpan(spanName, parentSpan);
+    const span = await createSpan(spanName, parentSpan, { kind: spanKind || SpanKind.INTERNAL });
     try {
       return await runWithSpan(span, () => innerMethod(span));
     } catch (ex) {


### PR DESCRIPTION
This PR:

- Includes the `SpanKind` field in the instrumentation for HTTP routes, DB calls, Cache calls, Queue system, etc.
- Verifies the `SpanName` used in the Span generation and improves it according to the OTEL specification.

**Specification:** 
- https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#span
- https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/README.md

## Fixes

- https://github.com/kubeshop/tracetest/issues/816

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
