### PR TITLE
remove server url

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -3,8 +3,6 @@ info:
   title: Pokemon Api
   version: 0.0.8
   description: OpenAPI description for endpoints and and resources of the Pokemon API
-servers:
-  - url: /api
 paths:
   /pokemon:
     get:


### PR DESCRIPTION
This PR removes the server path from the openapi spec. None of the endpoints starts with /api

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
