### PR TITLE
Added getById endpoint, that uses cache

### DIFF
--- a/.github/workflows/community-issue-notification.yml
+++ b/.github/workflows/community-issue-notification.yml
@@ -15,7 +15,7 @@ jobs:
         if: github.event.action == 'opened'
         uses: mathnogueira/user-blocklist@1.0.0
         with:
-          blocked_users: cescoferraro, jfermi, jorgeepc, kdhamric, mathnogueira, olha23, schoren, xoscar
+          blocked_users: cescoferraro, jfermi, jorgeepc, kdhamric, mathnogueira, olha23, schoren, xoscar, danielbdias
 
       - name: Notify us if not a kubeshop member
         if: |

--- a/.github/workflows/community-pr-notification.yml
+++ b/.github/workflows/community-pr-notification.yml
@@ -15,7 +15,7 @@ jobs:
         if: github.event.action == 'opened'
         uses: mathnogueira/user-blocklist@1.0.0
         with:
-          blocked_users: cescoferraro, jfermi, jorgeepc, kdhamric, mathnogueira, olha23, schoren, xoscar
+          blocked_users: cescoferraro, jfermi, jorgeepc, kdhamric, mathnogueira, olha23, schoren, xoscar, danielbdias
 
       - name: Notify us if not a kubeshop member
         if: |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # Pokeshop
-This is a demo application instrumented with opentelemetry to generate traces. It was created to be used in our demo page of [Tracetest](https://github.com/kubeshop/tracetest).
 
-## Summary
+This is a demo application instrumented with Open Telemetry to generate traces. 
+It was created to be used in our demo page of [Tracetest](https://github.com/kubeshop/tracetest).
+
+You can see a detailed explanation of Tracetest documentation: https://docs.tracetest.io/live-examples/pokeshop/
+
+## Additional information
+
 1. [API Overview](https://github.com/kubeshop/pokeshop/blob/master/docs/overview.md)
 2. [Installation](https://github.com/kubeshop/pokeshop/blob/master/docs/installing.md)
 3. [OpenAPI specs](https://github.com/kubeshop/pokeshop/blob/master/openapi/openapi.yaml)

--- a/api/package.json
+++ b/api/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "api",
+  "name": "PokeshopAPI",
   "version": "1.0.0",
-  "description": "<!-- title: 'AWS Simple HTTP Endpoint example in NodeJS' description: 'This template demonstrates how to make a simple HTTP API with Node.js running on AWS Lambda and API Gateway using the Serverless Framework.' layout: Doc framework: v3 platform: AWS language: nodeJS authorLink: 'https://github.com/serverless' authorName: 'Serverless, inc.' authorAvatar: 'https://avatars1.githubusercontent.com/u/13742415?s=200&v=4' -->",
+  "description": "This is a demo application instrumented with Open Telemetry to generate traces based on PokeAPI",
   "main": "handler.js",
   "scripts": {
     "generate:proto": "cd ./protos && protoc --plugin=../node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=../src/protos --ts_proto_opt=outputServices=grpc-js ./pokeshop.proto",

--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -28,6 +28,7 @@ async function startApp() {
   await setupSequelize();
 
   const routeSetupFunctions = [
+    healthcheckHandler, // should be first than getByIdHandler since both paths could collide
     createHandler,
     getHandler,
     getByIdHandler,
@@ -36,7 +37,6 @@ async function startApp() {
     removeHandler,
     searchHandler,
     updateHandler,
-    healthcheckHandler,
   ];
 
   for (const routeSetup of routeSetupFunctions) {
@@ -53,10 +53,6 @@ async function startApp() {
 
   ui.use(serve(resolve(__dirname, './ui')));
   app.use(mount('/', ui));
-
-  app.on('error', (err, ctx) => {
-    console.log(err);
-  });
 
   console.log(`Starting server on port ${APP_PORT}`);
   app.listen(APP_PORT);

--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -8,6 +8,7 @@ import cors from '@koa/cors';
 import { resolve } from 'path';
 import createHandler from '@pokemon/handlers/create.handler';
 import getHandler from '@pokemon/handlers/get.handler';
+import getByIdHandler from '@pokemon/handlers/getbyid.handler';
 import featuredHandler from '@pokemon/handlers/featured.handler';
 import importHandler from '@pokemon/handlers/import.handler';
 import removeHandler from '@pokemon/handlers/remove.handler';
@@ -29,6 +30,7 @@ async function startApp() {
   const routeSetupFunctions = [
     createHandler,
     getHandler,
+    getByIdHandler,
     featuredHandler,
     importHandler,
     removeHandler,
@@ -51,6 +53,10 @@ async function startApp() {
 
   ui.use(serve(resolve(__dirname, './ui')));
   app.use(mount('/', ui));
+
+  app.on('error', (err, ctx) => {
+    console.log(err);
+  });
 
   console.log(`Starting server on port ${APP_PORT}`);
   app.listen(APP_PORT);

--- a/api/src/handlers/getbyid.handler.ts
+++ b/api/src/handlers/getbyid.handler.ts
@@ -3,6 +3,7 @@ import { getPokemonRepository } from '@pokemon/repositories';
 import { getCacheService } from '@pokemon/services/cache.service';
 
 const cache = getCacheService();
+const repository = getPokemonRepository();
 
 const getById = async (ctx, next) => {
   const { id = '0' } = ctx.params || {};
@@ -11,8 +12,6 @@ const getById = async (ctx, next) => {
   if (!!cachedPokemon) {
     return cachedPokemon; // cache hit
   }
-
-  const repository = getPokemonRepository();
 
   const databasePokemon = await repository.findOne(id);
 

--- a/api/src/handlers/getbyid.handler.ts
+++ b/api/src/handlers/getbyid.handler.ts
@@ -1,0 +1,33 @@
+import { jsonResponse } from '@pokemon/middlewares/response';
+import { getPokemonRepository } from '@pokemon/repositories';
+import { getCacheService } from '@pokemon/services/cache.service';
+
+const cache = getCacheService();
+
+const getById = async (ctx, next) => {
+  const { id = '0' } = ctx.params || {};
+
+  const cachedPokemon = await cache.get(`pokemon-${id}`);
+  if (!!cachedPokemon) {
+    return cachedPokemon; // cache hit
+  }
+
+  const repository = getPokemonRepository();
+
+  const databasePokemon = await repository.findOne(id);
+
+  if (!!databasePokemon) {
+    cache.set(`pokemon-${id}`, databasePokemon);
+  }
+
+  if (!databasePokemon) {
+    ctx.status = 404;
+    return;
+  }
+
+  return databasePokemon;
+};
+
+export default function setupRoute(router) {
+  router.get('/pokemon/:id', jsonResponse(200), getById);
+}

--- a/api/src/handlers/remove.handler.ts
+++ b/api/src/handlers/remove.handler.ts
@@ -14,7 +14,7 @@ const remove = async ctx => {
     return;
   }
 
-  cache.set(`pokemon-${id}`, null)
+  cache.invalidate(`pokemon-${id}`)
 
   await repository.delete(+id);
   return pokemon;

--- a/api/src/handlers/remove.handler.ts
+++ b/api/src/handlers/remove.handler.ts
@@ -1,5 +1,8 @@
 import { jsonResponse } from '@pokemon/middlewares/response';
 import { getPokemonRepository } from '@pokemon/repositories';
+import { getCacheService } from '@pokemon/services/cache.service';
+
+const cache = getCacheService();
 
 const remove = async ctx => {
   const { id = '0' } = ctx.params || {};
@@ -10,6 +13,8 @@ const remove = async ctx => {
     ctx.status = 404;
     return;
   }
+
+  cache.set(`pokemon-${id}`, null)
 
   await repository.delete(+id);
   return pokemon;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       interval: 1s
       timeout: 5s
       retries: 60
+
   cache:
     image: redis:6
     ports:
@@ -24,6 +25,7 @@ services:
       interval: 1s
       timeout: 3s
       retries: 60
+
   queue:
     image: rabbitmq:3.9
     ports:
@@ -34,6 +36,7 @@ services:
       interval: 1s
       timeout: 5s
       retries: 60
+
   jaeger:
     image: jaegertracing/all-in-one:latest
     ports:

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -1,8 +1,8 @@
 # Installing
-here are the instructions on how to run this demo project.
 
 ## Run it locally
-To try it locally, you can use `docker-compose` to run the api, its worker and all its dependencies.
+
+To try it locally, you can use `docker-compose` to run the API, its Worker, and all its dependencies.
 
 ### Requirements
 - [docker](https://www.docker.com/get-started/)
@@ -11,7 +11,7 @@ To try it locally, you can use `docker-compose` to run the api, its worker and a
 ### Steps
 
 1. Clone the project
-2. Go to the api folder inside the project folder
+2. Go to the `api` folder inside the project folder
 3. Execute `docker-compose up`
 
 ### Script
@@ -22,7 +22,8 @@ cd pokeshop/api
 docker-compose up
 ```
 
-## Run on a kubernetes cluster
+## Run on a Kubernetes cluster
+
 If you want to run this project on a real cluster, we provide a helm chart to install it. This installation doesn't create a jaeger instance for you, so you have to install it manually and set the `JAEGER_HOST` and `JAEGER_PORT` on the `env` section of the file `helm-chart/values.yml`.
 
 ### Requirements

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,4 +1,5 @@
 # API overview
+
 The primary goal of this API is not to provide functionality for its users, it was built to be used by the [Tracetest] team as an API to be used in our demo. It's secondary goal is to act as an example of how to instrument REST APIs using OpenTelemetry. So, if you want to understand how to instrument an API using OpenTelemetry, this API might be a good starting point.
 
 ## Endpoints
@@ -115,7 +116,6 @@ Failed response:
 ```js
 // POST /pokemon/import
 ```
-
 
 ```json
 {

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -76,6 +76,28 @@ paths:
                 items:
                   $ref: "#/components/schemas/Pokemon"
   /pokemon/{id}:
+    get:
+      tags:
+        - api
+      summary: get a specific pokemon
+      description: get the pokemon identified by the provided id
+      operationId: getPokemonById
+      parameters:
+        - in: path
+          name: id
+          description: id of the pokemon that will be retrieved
+          schema:
+            type: integer
+          required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pokemon"
+        404:
+          description: specified pokemon doesn't exist
     delete:
       tags:
         - api


### PR DESCRIPTION
This PR adds another endpoint, that has a cache hit/miss example.

Example of get by Id with cache miss:
<img width="827" alt="image" src="https://user-images.githubusercontent.com/12397879/215162924-77640a98-87ea-4303-a678-a8613a550a90.png">

Example of get by Id with cache hit:
<img width="583" alt="image" src="https://user-images.githubusercontent.com/12397879/215163081-62557e7b-38af-4c6c-a7b3-dc3e83bc09c4.png">


## Changes

- Adding getById endpoint with caching
- Update delete endpoint to invalidate cache
- Update cache duration

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
