### PR TITLE
add span event to request validation middleware

### DIFF
--- a/api/src/middlewares/validation.ts
+++ b/api/src/middlewares/validation.ts
@@ -7,12 +7,14 @@ const validate = type => {
   return async function validate(ctx, next) {
     const parentSpan = await getParentSpan();
     const span = await createSpan('validate request', parentSpan, { kind: SpanKind.INTERNAL });
+    span.addEvent("validation started")
 
     const body = ctx.request.body;
     try {
       const validType = await runWithSpan(span, async () => await transformAndValidate(type, body));
       ctx.body = validType;
       span.setAttribute(CustomTags.VALIDATION_IS_VALID, true);
+      span.addEvent("request is valid", {[CustomTags.VALIDATION_IS_VALID]: true})
       return runWithSpan(span, async () => await next(ctx));
     } catch (validationErrors) {
       ctx.status = 400;
@@ -22,6 +24,11 @@ const validate = type => {
         [CustomTags.VALIDATION_ERRORS]: JSON.stringify(response.errors),
         [CustomTags.VALIDATION_IS_VALID]: false,
       });
+      span.addEvent("request is invalid", {
+        [CustomTags.VALIDATION_ERRORS]: JSON.stringify(response.errors),
+        [CustomTags.VALIDATION_IS_VALID]: false,
+      })
+
       span.setStatus({ code: SpanStatusCode.ERROR });
       ctx.body = response;
       return response;


### PR DESCRIPTION
This PR adds an event to the validate request span as an example

## Changes
![image](https://github.com/kubeshop/pokeshop/assets/2704737/f80d882e-963d-4094-be9b-9ef2fea3fa47)


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
