### PR TITLE
chore: adding Kafka to Pokeshop Helm charts

### DIFF
--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -51,6 +51,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Selector labels (stream)
+*/}}
+{{- define "pokemon-api.selectorLabelsStream" -}}
+app.kubernetes.io/name: {{ include "pokemon-api.name" . }}-stream
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "pokemon-api.serviceAccountName" -}}

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -80,6 +80,23 @@ spec:
             - name: SERVICE_NAME
               value: pokeshop
             {{- toYaml .Values.env | nindent 12 }}
+        - name: {{ .Chart.Name }}-stream-worker
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            - name: NPM_RUN_COMMAND
+              value: stream-worker
+            - name: SERVICE_NAME
+              value: pokeshop-stream-worker
+            {{- toYaml .Values.env | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/templates/stream.deployment.yaml
+++ b/helm-chart/templates/stream.deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "pokemon-api.fullname" . }}-stream
+  labels:
+    {{- include "pokemon-api.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "pokemon-api.selectorLabelsStream" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "pokemon-api.selectorLabelsStream" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}-stream
+          image: "confluentinc/cp-kafka:latest-ubi8"
+          imagePullPolicy: IfNotPresent
+          ports:                                                                                                                                                                                                                       
+            - containerPort: 9092                                                                                                                                                                                                               
+              name: plaintext                                                                                                                                                                                                                   
+              protocol: TCP                                                                                                                                                                                                                     
+            - containerPort: 9093                                                                                                                                                                                                               
+              name: controller                                                                                                                                                                                                                  
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.kafka.resources | nindent 12 }}
+          env: 
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: PLAINTEXT://stream.{{ .Release.Namespace }}:9092
+            - name: KAFKA_LISTENERS
+              value: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
+            - name: KAFKA_CONTROLLER_QUORUM_VOTERS
+              value: 1@0.0.0.0:9093
+            - name: KAFKA_CONTROLLER_LISTENER_NAMES
+              value: CONTROLLER
+            - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+              value: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+            - name: KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS
+              value: "0"
+            - name: KAFKA_PROCESS_ROLES
+              value: controller,broker
+            - name: KAFKA_NODE_ID
+              value: "1"
+            - name: KAFKA_METADATA_LOG_SEGMENT_MS
+              value: "15000"
+            - name: KAFKA_METADATA_MAX_RETENTION_MS
+              value: "60000"
+            - name: KAFKA_METADATA_LOG_MAX_RECORD_BYTES_BETWEEN_SNAPSHOTS
+              value: "2800"
+            - name: KAFKA_AUTO_CREATE_TOPICS_ENABLE
+              value: "true"
+            - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_HEAP_OPTS
+              value: -Xmx200m -Xms200m
+            - name: CLUSTER_ID
+              value: ckjPoprWQzOf0-FuNkGfFQ

--- a/helm-chart/templates/stream.service.yaml
+++ b/helm-chart/templates/stream.service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: stream
+  labels:
+    {{- include "pokemon-api.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: plaintext                                                                                                                                                                                                                        
+      port: 9092                                                                                                                                                                                                                              
+      protocol: TCP                                                                                                                                                                                                                           
+      targetPort: 9092                                                                                                                                                                                                                        
+    - name: controller                                                                                                                                                                                                                        
+      port: 9093                                                                                                                                                                                                                              
+      protocol: TCP                                                                                                                                                                                                                           
+      targetPort: 9093
+
+  selector:
+    {{- include "pokemon-api.selectorLabelsStream" . | nindent 4 }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -23,6 +23,12 @@ env:
     value: http://otel-collector.tracetest.svc.cluster.local:4317
   - name: ZIPKIN_URL
     value: http://jaeger-agent.tracetest.svc.cluster.local:9411
+  - name: KAFKA_BROKER
+    value: stream:9092
+  - name: KAFKA_TOPIC
+    value: pokemon
+  - name: KAFKA_CLIENT_ID
+    value: streaming-worker
 
 imagePullSecrets: []
 nameOverride: ""
@@ -93,6 +99,12 @@ tolerations: []
 affinity: {}
 
 # Dependencies configuration
+kafka:
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+
 postgresql:
   fullnameOverride: postgresql
   auth:


### PR DESCRIPTION
This PR adds the new worker structure to our Helm charts.

## Changes

-

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
