### PR TITLE
Quality of life improvements from workshop delivery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,18 @@ SRCDIR        = docs/diagrams
 OUTPUT_FORMAT = png
 SRC           = $(wildcard $(SRCDIR)/*.mdd)
 OUT           = ${SRC:.mdd=.$(OUTPUT_FORMAT)}
+DETACHED      ?= false
+BUILD         ?= false
+FLAGS          = ""
 
 help: Makefile ## show list of commands
 	@echo "Choose a command run:"
 	@echo ""
 	@awk 'BEGIN {FS = ":.*?## "} /[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-40s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
+
+generate-flags:
+if ${DETACHED}; then FLAGS += " --detach"; fi
+if ${BUILD}; then FLAGS += " --build"; fi
 
 generate-diagrams: $(OUT)
 
@@ -14,7 +21,7 @@ $(SRCDIR)/%.$(OUTPUT_FORMAT): $(SRCDIR)/%.mdd
 	npm run generate-diagram -- --input $< --output $@
 
 run/pokeshop: ## run Pokeshop API on docker compose
-	docker compose -f docker-compose.yml -f ./docker-compose.stream.yml up
+	docker compose -f docker-compose.yml -f ./docker-compose.stream.yml up ${FLAGS}
 
 down/pokeshop: ## stop Pokeshop API running on docker compose
 	docker compose -f docker-compose.yml -f ./docker-compose.stream.yml  down
@@ -23,7 +30,7 @@ run/tracetests: ## run Trace-based tests on Pokeshop API with Tracetest
 	docker compose -f docker-compose.yml -f ./docker-compose.stream.yml -f ./tracetest/docker-compose.yml run tracebased-tests
 
 run: ## run Pokeshop API on Docker Compose and run Trace-based tests with Tracetest
-	docker compose -f docker-compose.yml -f ./docker-compose.stream.yml -f ./tracetest/docker-compose.yml up
+	docker compose -f docker-compose.yml -f ./docker-compose.stream.yml -f ./tracetest/docker-compose.yml up ${FLAGS}
 
 down: ## stop Pokeshop API on Docker Compose and run Trace-based tests with Tracetest
 	docker compose -f docker-compose.yml -f ./docker-compose.stream.yml -f ./tracetest/docker-compose.yml down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       retries: 60
 
   queue:
-    image: rabbitmq:3.9
+    image: rabbitmq:3.12
     restart: unless-stopped
     ports:
       - 5672:5672

--- a/tracetest/config/tracetest-config.yaml
+++ b/tracetest/config/tracetest-config.yaml
@@ -19,3 +19,4 @@ telemetry:
 server:
   telemetry:
     exporter: collector
+    applicationExporter: collector

--- a/tracetest/docker-compose.yml
+++ b/tracetest/docker-compose.yml
@@ -3,7 +3,6 @@ version: '3'
 services:
     tracebased-tests:
         image: kubeshop/tracetest:${TAG:-latest}
-        platform: linux/amd64
         volumes:
             - type: bind
               source: ./tracetest/tests
@@ -26,7 +25,6 @@ services:
     
     tracetest-server:
         image: kubeshop/tracetest:${TAG:-latest}
-        platform: linux/amd64
         volumes:
             - type: bind
               source: ./tracetest/config/tracetest-config.yaml

--- a/web/src/gateways/pokemon.ts
+++ b/web/src/gateways/pokemon.ts
@@ -18,7 +18,7 @@ const PokemonGateway = () => ({
 
     return pokemonList;
   },
-  async create({ imageUrl, name, type, isFeatured }: TCreatePokemon) {
+  async create({ imageUrl, name, type, isFeatured = false }: TCreatePokemon) {
     const pokemon = await request<TPokemon>({
       url: `${BASE_API}`,
       method: 'POST',


### PR DESCRIPTION
This PR captures 5 quality of life improvements I introduced when using Pokeshop to run a workshop about TraceTest.

## Changes

- Provides two new env vars for the Makefile to manage more complex scenarios like building and detached mode.
- Upgrades RabbitMQ since 3.9 is out of service and throws errors. 12 "just worked" but I did not do extensive testing.
- Defaults to adding `applicationExported in the TraceTest config as I believe this is a nice feature and there is no known risk to this default.
- Removes requirement for AMD platform when running the TraceTest `docker-compose.yml` file. This is tested on a M1 mac and a Ubuntu VM.

## Fixes

- The Web service previously fails if you try and create a non-featured pokemon. The issue presents as a failed API request due to a null value rather than a false one.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
