### PR TITLE
fix: makefile typos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,20 @@ SRC           = $(wildcard $(SRCDIR)/*.mdd)
 OUT           = ${SRC:.mdd=.$(OUTPUT_FORMAT)}
 DETACHED      ?= false
 BUILD         ?= false
-FLAGS          = ""
+export FLAGS
 
 help: Makefile ## show list of commands
 	@echo "Choose a command run:"
 	@echo ""
 	@awk 'BEGIN {FS = ":.*?## "} /[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-40s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
 
-generate-flags:
-if ${DETACHED}; then FLAGS += " --detach"; fi
-if ${BUILD}; then FLAGS += " --build"; fi
+ifeq ($(DETACHED),true)
+  FLAGS+= --detach
+endif
+
+ifeq ($(BUILD),true)
+  FLAGS+= --build
+endif
 
 generate-diagrams: $(OUT)
 


### PR DESCRIPTION
This PR fixes things from my last PR. Sorry! 🙈

## Changes

-

## Fixes

1. The empty string creates errors for flags, empty needs to be empty
1. Remove generate flag target and just (correctly) set the vars on each run

## Checklist

- [x] tested locally
👇 This is proof of it working both with and without the env var for detached
<img width="882" alt="image" src="https://github.com/kubeshop/pokeshop/assets/1557346/a2da90e5-9b8f-4336-9e2d-15dd4675f8f8">
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
