### PR TITLE
chore: fix npm ci problem in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ FROM node:alpine as app
 
 WORKDIR /app
 COPY ./api/package.json ./api/package-lock.json ./
-RUN npm clean-install
+RUN npm clean-install --maxsocket 1
 
 EXPOSE 80
 


### PR DESCRIPTION
This PR uses the `--maxsockets` parameter to fix the `CONNRESET` error.


## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
