### PR TITLE
chore: adding otel setup logging

### DIFF
--- a/api/src/telemetry/tracing.ts
+++ b/api/src/telemetry/tracing.ts
@@ -5,6 +5,9 @@ import { Resource } from '@opentelemetry/resources';
 import * as dotenv from 'dotenv';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import { SpanStatusCode } from '@opentelemetry/api';
+import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
+
+diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
 
 // Make sure all env variables are available in process.env
 dotenv.config();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,34 @@ services:
       retries: 60
     ports:
       - 8081:8081
+    depends_on:
+      db:
+        condition: service_healthy
+      cache:
+        condition: service_healthy
+      queue:
+        condition: service_healthy
+      jaeger:
+        condition: service_healthy
+      otel-collector:
+        condition: service_started
+  
+  rpc:
+    build: .
+    environment:
+      REDIS_URL: cache
+      DATABASE_URL: postgresql://ashketchum:squirtle123@db:5432/pokeshop?schema=public
+      RABBITMQ_HOST: queue
+      POKE_API_BASE_URL: https://pokeapi.co/api/v2
+      COLLECTOR_ENDPOINT: http://otel-collector:4317
+      ZIPKIN_URL: http://localhost:9411
+      NPM_RUN_COMMAND: rpc
+    healthcheck:
+      test: ['CMD', 'wget', '--spider', 'localhost:8081/pokemon/healthcheck']
+      interval: 1s
+      timeout: 3s
+      retries: 60
+    ports:
       - 8082:8082
     depends_on:
       db:


### PR DESCRIPTION
This PR adds logging to the open telemetry setups and includes the rpc container in the `docker-compose` file.

## Changes

- Adds tracing logging


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
