### PR TITLE
chore: add fallbacks to restart streamWorker if kafka connection breaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,3 +38,6 @@ run: ## run Pokeshop API on Docker Compose and run Trace-based tests with Tracet
 
 down: ## stop Pokeshop API on Docker Compose and run Trace-based tests with Tracetest
 	docker compose -f docker-compose.yml -f ./docker-compose.stream.yml -f ./tracetest/docker-compose.yml down
+
+build/docker: # build docker image locally
+	docker build . -t kubeshop/demo-pokemon-api:latest

--- a/docker-compose.stream.yml
+++ b/docker-compose.stream.yml
@@ -42,6 +42,7 @@ services:
       KAFKA_TOPIC: 'pokemon'
       KAFKA_CLIENT_ID: 'streaming-worker'
       REDIS_URL: cache
+    restart: on-failure
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
This PR adds a fallback to kill the stream worker, allowing it to be restarted in case of connection breaks with kafka.

## Changes

- Updated stream service to halt in case of Kafka consumer crash

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
