### PR TITLE
chore: move community links to slack

### DIFF
--- a/web/src/components/Header/HeaderMenu.tsx
+++ b/web/src/components/Header/HeaderMenu.tsx
@@ -1,4 +1,4 @@
-import { DOCUMENTATION_URL, GITHUB_URL, DISCORD_URL } from '../../constants/common';
+import { DOCUMENTATION_URL, GITHUB_URL, COMMUNITY_SLACK_URL } from '../../constants/common';
 import * as S from './Header.styled';
 
 interface IProps {
@@ -27,10 +27,10 @@ export const HeaderMenu = ({ pathname }: IProps) => {
           ),
         },
         {
-          key: 'discord',
+          key: 'slack',
           label: (
-            <a href={DISCORD_URL} target="_blank" data-cy="discord-link">
-              Discord
+            <a href={COMMUNITY_SLACK_URL} target="_blank" data-cy="slack-link">
+              Slack
             </a>
           ),
         },

--- a/web/src/constants/common.ts
+++ b/web/src/constants/common.ts
@@ -1,4 +1,4 @@
 export const DOCUMENTATION_URL = 'https://docs.tracetest.io';
 export const GITHUB_URL = 'https://github.com/kubeshop/tracetest';
 export const GITHUB_ISSUES_URL = 'https://github.com/kubeshop/tracetest/issues/new/choose';
-export const DISCORD_URL = 'https://discord.gg/6zupCZFQbe';
+export const COMMUNITY_SLACK_URL = 'https://dub.sh/tracetest-community';


### PR DESCRIPTION
This PR updates the community links to use Slack instead of Discord

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
