### PR TITLE
feat: allow user to disable cache lookup via request body

### DIFF
--- a/api/src/graphql/import.resolver.ts
+++ b/api/src/graphql/import.resolver.ts
@@ -4,8 +4,8 @@ import PokemonSyncronizer from '@pokemon/services/pokemonSyncronizer.service';
 const pokeApiService = new PokeAPIService();
 const pokemonSyncronizer = PokemonSyncronizer(pokeApiService);
 
-const importPokemon = async ({ id = 0 }) => {
-  await pokemonSyncronizer.queue({ id });
+const importPokemon = async ({ id = 0, ignoreCache = false }) => {
+  await pokemonSyncronizer.queue({ id, ignoreCache });
 
   return { id };
 };

--- a/api/src/handlers/import.handler.ts
+++ b/api/src/handlers/import.handler.ts
@@ -8,10 +8,11 @@ const pokeApiService = new PokeAPIService();
 const pokemonSyncronizer = PokemonSyncronizer(pokeApiService);
 
 const importPokemon = async (ctx: { body: ImportPokemon }) => {
-  const { id = 0 } = ctx.body;
+  const { id = 0, ignoreCache = false } = ctx.body;
 
   await pokemonSyncronizer.queue({
     id: id,
+    ignoreCache: ignoreCache,
   });
 
   return {

--- a/api/src/handlers/streamSyncronize.handler.ts
+++ b/api/src/handlers/streamSyncronize.handler.ts
@@ -12,8 +12,8 @@ const pokemonSyncronizationHandler = async (message: KafkaMessage) => {
     return;
   }
 
-  const { id }: TPokemonSyncMessage = JSON.parse(messageString);
-  await pokemonSyncronizer.sync(id);
+  const msg: TPokemonSyncMessage = JSON.parse(messageString);
+  await pokemonSyncronizer.sync(msg);
 };
 
 export default function setupWorker(streamService: StreamingService<TPokemonSyncMessage>) {

--- a/api/src/handlers/syncronize.handler.ts
+++ b/api/src/handlers/syncronize.handler.ts
@@ -6,9 +6,9 @@ import ampqlib from 'amqplib';
 const pokemonSyncronizationHandler = async (message: ampqlib.ConsumeMessage) => {
   const pokeApiService = new PokeAPIService();
   const pokemonSyncronizer = PokemonSyncronizer(pokeApiService);
-  const { id }: TPokemonSyncMessage = JSON.parse(message.content.toString());
+  const pokemonSyncMessage: TPokemonSyncMessage = JSON.parse(message.content.toString());
 
-  await pokemonSyncronizer.sync(id);
+  await pokemonSyncronizer.sync(pokemonSyncMessage);
 };
 
 export default function setupWorker(queueService: QueueService<TPokemonSyncMessage>) {

--- a/api/src/protos/pokeshop.ts
+++ b/api/src/protos/pokeshop.ts
@@ -18,6 +18,7 @@ export const protobufPackage = "pokeshop";
 export interface ImportPokemonRequest {
   id: number;
   isFixed?: boolean | undefined;
+  ignoreCache?: boolean | undefined;
 }
 
 export interface GetPokemonRequest {

--- a/api/src/services/pokemonRpc.service.ts
+++ b/api/src/services/pokemonRpc.service.ts
@@ -25,9 +25,10 @@ const PokemonRpcService = (): PokeshopServer => ({
 
     callback(null, pokemon);
   },
-  async importPokemon({ request: { id } }, callback) {
+  async importPokemon({ request: { id, ignoreCache }}, callback) {
     await pokemonSyncronizer.queue({
-      id: id,
+      id,
+      ignoreCache: ignoreCache ?? false,
     });
 
     callback(null, { id });

--- a/api/src/services/queue.service.ts
+++ b/api/src/services/queue.service.ts
@@ -111,11 +111,11 @@ class RabbitQueueService<T> implements QueueService<T> {
     this.messageGroup = messageGroup;
   }
 
-  private async connect(useCache: boolean = true): Promise<ampqlib.Channel> {
+  private async connect(ignoreCache: boolean = true): Promise<ampqlib.Channel> {
     let lastError;
     for (let i = 0; i < 10; i++) {
       try {
-        return await this._connect(useCache)
+        return await this._connect(ignoreCache)
       } catch (ex) {
         lastError = ex
         await new Promise(r => setTimeout(r, 2000));
@@ -125,8 +125,8 @@ class RabbitQueueService<T> implements QueueService<T> {
     throw new Error(`could not connect after 10 tries: ${lastError?.message}`)
   }
 
-  private async _connect(useCache: boolean = true): Promise<ampqlib.Channel> {
-    if (useCache && this.channel) {
+  private async _connect(ignoreCache: boolean = true): Promise<ampqlib.Channel> {
+    if (ignoreCache && this.channel) {
       return this.channel;
     }
 

--- a/api/src/validators/importPokemon.ts
+++ b/api/src/validators/importPokemon.ts
@@ -4,6 +4,8 @@ class ImportPokemon {
   @IsNumber()
   @IsPositive()
   public id: number;
+
+  public ignoreCache: boolean;
 }
 
 export default ImportPokemon;


### PR DESCRIPTION
This PR allows users to define if they want to use or not the cached result when importing a pokemon. This is part of the pokeshop stabilization plan.

By default, it doesn't change the behavior of the import handler, it only disables the cache layer if the user passes the attribute `ignoreCache: true`

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
